### PR TITLE
Changes bit shift/mask logic for divide by 3

### DIFF
--- a/iterators.js
+++ b/iterators.js
@@ -9,15 +9,15 @@ if (!global.gc) {
 const filterMapFilterInline = (nums) =>
   nums
     .filter((n) => n % 3 == 0)
-    .map((n) => n & (255 << 8))
+    .map((n) => n / 3)
     .filter((n) => n % 3 == 0);
 
 const reduceInline = (nums) =>
   nums.reduce((result, n) => {
     if (n % 3 == 0) {
-      const highBits = n & (255 << 8);
-      if (highBits % 3 == 0) {
-        result.push(highBits);
+      const third = n / 3;
+      if (third % 3 == 0) {
+        result.push(third);
       }
     }
     return result;
@@ -28,9 +28,9 @@ const forLoopInline = (nums) => {
   for (let i = 0; i < nums.length; i++) {
     n = nums[i];
     if (n % 3 == 0) {
-      const highBits = n & (255 << 8);
-      if (highBits % 3 == 0) {
-        result.push(highBits);
+      const third = n / 3;
+      if (third % 3 == 0) {
+        result.push(third);
       }
     }
   }
@@ -38,17 +38,17 @@ const forLoopInline = (nums) => {
 };
 
 const divisibleBy3 = (n) => n % 3 === 0;
-const secondByte = (n) => n & (255 << 8);
+const divideBy3 = (n) => n / 3;
 
 const filterMapFilterCallback = (nums) =>
-  nums.filter(divisibleBy3).map(secondByte).filter(divisibleBy3);
+  nums.filter(divisibleBy3).map(divideBy3).filter(divisibleBy3);
 
 const reduceCallback = (nums) =>
   nums.reduce((result, n) => {
     if (divisibleBy3(n)) {
-      const highBits = secondByte(n);
-      if (divisibleBy3(highBits)) {
-        result.push(highBits);
+      const third = divideBy3(n);
+      if (divisibleBy3(third)) {
+        result.push(third);
       }
     }
     return result;
@@ -59,9 +59,9 @@ const forLoopCallback = (nums) => {
   for (let i = 0; i < nums.length; i++) {
     n = nums[i];
     if (divisibleBy3(n)) {
-      const highBits = secondByte(n);
-      if (divisibleBy3(highBits)) {
-        result.push(highBits);
+      const third = divideBy3(n);
+      if (divisibleBy3(third)) {
+        result.push(third);
       }
     }
   }
@@ -69,15 +69,10 @@ const forLoopCallback = (nums) => {
 };
 
 function testFunc(method) {
-  const smallNums = [0, (3 << 8) | 3, (4 << 8) + 2, (3 << 8) + 1, (6 << 8) | 3];
+  const smallNums = [0, 3, 6, 9];
   const result = method(smallNums);
 
-  return (
-    result.length === 3 &&
-    result[0] === 0 &&
-    result[1] === 3 << 8 &&
-    result[2] === 6 << 8
-  );
+  return result.length === 2 && result[0] === 0 && result[1] === 3;
 }
 
 if (

--- a/iterators.rb
+++ b/iterators.rb
@@ -4,16 +4,16 @@ require 'memory_profiler'
 def filter_map_filter_inline(nums)
   nums
     .filter { |n| n % 3 == 0 }
-    .map { |n| n & (255 << 8) }
+    .map { |n| n / 3 }
     .filter { |n| n % 3 == 0 }
 end
 
 def reduce_inline(nums)
   nums.reduce([]) do |result, n|
     if n % 3 == 0
-      high_bits = n & (255 << 8)
-      if high_bits % 3 == 0
-        result << high_bits
+      third = n / 3
+      if third % 3 == 0
+        result << third
       end
     end
 
@@ -27,9 +27,9 @@ def while_loop_inline(nums)
   while idx < nums.length do
     n = nums[idx]
     if n % 3 == 0
-      high_bits = n & (255 << 8)
-      if high_bits % 3 == 0
-        result << high_bits
+      third = n / 3
+      if third % 3 == 0
+        result << third
       end
     end
 
@@ -43,23 +43,23 @@ def divisible_by_3?(n)
   n % 3 == 0
 end
 
-def second_byte(n)
-  n & (255 << 8)
+def divide_by_3(n)
+  n / 3
 end
 
 def filter_map_filter_callback(nums)
   nums
     .filter { |n| divisible_by_3?(n) }
-    .map { |n| second_byte(n) }
+    .map { |n| divide_by_3(n) }
     .filter { |n| divisible_by_3?(n) }
 end
 
 def reduce_callback(nums)
   nums.reduce([]) do |result, n|
     if divisible_by_3?(n)
-      high_bits = second_byte(n)
-      if divisible_by_3?(high_bits)
-        result << high_bits
+      third = divide_by_3(n)
+      if divisible_by_3?(third)
+        result << third
       end
     end
 
@@ -73,9 +73,9 @@ def while_loop_callback(nums)
   while idx < nums.length do
     n = nums[idx]
     if divisible_by_3?(n)
-      high_bits = second_byte(n)
-      if divisible_by_3?(high_bits)
-        result << high_bits
+      third = divide_by_3(n)
+      if divisible_by_3?(third)
+        result << third
       end
     end
 
@@ -85,8 +85,8 @@ def while_loop_callback(nums)
   result
 end
 
-small_nums = [0, (3 << 8) | 3, (4 << 8) + 2, (3 << 8) + 1, (6 << 8) | 3];
-expected = [0, 3 << 8, 6 << 8]
+small_nums = [0, 3, 6, 9];
+expected = [0, 3]
 unless  filter_map_filter_callback(small_nums) == expected  &&
      reduce_callback(small_nums) == expected  &&
      while_loop_callback(small_nums) == expected  &&

--- a/iterators/src/lib.rs
+++ b/iterators/src/lib.rs
@@ -1,7 +1,7 @@
 pub fn filter_map_filter_inline(nums: &[u64]) -> Vec<u64> {
     nums.iter()
         .filter(|&&n| n % 3 == 0)
-        .map(|&n| n & (255 << 8))
+        .map(|&n| n / 3)
         .filter(|&n| n % 3 == 0)
         .collect()
 }
@@ -9,9 +9,9 @@ pub fn filter_map_filter_inline(nums: &[u64]) -> Vec<u64> {
 pub fn fold_inline(nums: &[u64]) -> Vec<u64> {
     nums.iter().fold(Vec::new(), |mut result, &n| {
         if n % 3 == 0 {
-            let high_bits = n & (255 << 8);
-            if high_bits % 3 == 0 {
-                result.push(high_bits);
+            let third = n / 3;
+            if third % 3 == 0 {
+                result.push(third);
             }
         }
         result
@@ -22,9 +22,9 @@ pub fn for_loop_inline(nums: &[u64]) -> Vec<u64> {
     let mut result = Vec::new();
     for n in nums {
         if n % 3 == 0 {
-            let high_bits = n & (255 << 8);
-            if high_bits % 3 == 0 {
-                result.push(high_bits);
+            let third = n / 3;
+            if third % 3 == 0 {
+                result.push(third);
             }
         }
     }
@@ -34,14 +34,14 @@ pub fn for_loop_inline(nums: &[u64]) -> Vec<u64> {
 fn divisible_by_3(n: u64) -> bool {
     n % 3 == 0
 }
-fn second_byte(n: u64) -> u64 {
-    n & (255 << 8)
+fn divide_by_3(n: u64) -> u64 {
+    n / 3
 }
 
 pub fn filter_map_filter_callback(nums: &[u64]) -> Vec<u64> {
     nums.iter()
         .filter(|&&n| divisible_by_3(n))
-        .map(|&n| second_byte(n))
+        .map(|&n| divide_by_3(n))
         .filter(|&n| divisible_by_3(n))
         .collect()
 }
@@ -49,9 +49,9 @@ pub fn filter_map_filter_callback(nums: &[u64]) -> Vec<u64> {
 pub fn fold_callback(nums: &[u64]) -> Vec<u64> {
     nums.iter().fold(Vec::new(), |mut result, &n| {
         if divisible_by_3(n) {
-            let high_bits = second_byte(n);
-            if divisible_by_3(high_bits) {
-                result.push(high_bits);
+            let byte = divide_by_3(n);
+            if divisible_by_3(byte) {
+                result.push(byte);
             }
         }
         result
@@ -62,9 +62,9 @@ pub fn for_loop_callback(nums: &[u64]) -> Vec<u64> {
     let mut result = Vec::new();
     for &n in nums {
         if divisible_by_3(n) {
-            let high_bits = second_byte(n);
-            if divisible_by_3(high_bits) {
-                result.push(high_bits);
+            let third = divide_by_3(n);
+            if divisible_by_3(third) {
+                result.push(third);
             }
         }
     }
@@ -75,57 +75,39 @@ pub fn for_loop_callback(nums: &[u64]) -> Vec<u64> {
 mod tests {
     use super::*;
 
+    macro_rules! test {
+        ($f:expr) => {
+            assert_eq!($f(&[0, 3, 6, 9]), vec![0, 3]);
+        };
+    }
+
     #[test]
     fn filter_map_filter_callback_works() {
-        assert_eq!(
-            filter_map_filter_callback(&[
-                0,
-                (3 << 8) | 3,
-                (4 << 8) | 3,
-                (3 << 8) | 4,
-                (6 << 8) | 3
-            ]),
-            vec![0, 3 << 8, 6 << 8]
-        )
+        test!(filter_map_filter_callback);
     }
 
     #[test]
     fn fold_callback_works() {
-        assert_eq!(
-            fold_callback(&[0, (3 << 8) | 3, (4 << 8) + 2, (3 << 8) + 1, (6 << 8) | 3]),
-            vec![0, 3 << 8, 6 << 8]
-        )
+        test!(fold_callback)
     }
 
     #[test]
     fn single_loop_works() {
-        assert_eq!(
-            for_loop_callback(&[0, (3 << 8) | 3, (4 << 8) + 2, (3 << 8) + 1, (6 << 8) | 3]),
-            vec![0, 3 << 8, 6 << 8]
-        )
+        test!(for_loop_callback);
     }
 
     #[test]
     fn multiple_inline_works() {
-        assert_eq!(
-            filter_map_filter_inline(&[0, (3 << 8) | 3, (4 << 8) + 2, (3 << 8) + 1, (6 << 8) | 3]),
-            vec![0, 3 << 8, 6 << 8]
-        )
+        test!(filter_map_filter_inline);
     }
 
     #[test]
     fn single_inline_works() {
-        assert_eq!(
-            fold_inline(&[0, (3 << 8) | 3, (4 << 8) + 2, (3 << 8) + 1, (6 << 8) | 3]),
-            vec![0, 3 << 8, 6 << 8]
-        )
+        test!(fold_inline);
     }
 
     #[test]
     fn single_loop_inline_works() {
-        assert_eq!(
-            for_loop_inline(&[0, (3 << 8) | 3, (4 << 8) + 2, (3 << 8) + 1, (6 << 8) | 3]),
-            vec![0, 3 << 8, 6 << 8]
-        )
+        test!(for_loop_inline);
     }
 }


### PR DESCRIPTION
I know this now makes it easy to argue, "well you could just
test divisibility by 9" but I think convoluting something to avoid that
isn't worth it because it doesn't affect the metrics (I don't think).